### PR TITLE
Update README DOUBLE QUOTATION Missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import TabBar from "@mindinventory/react-native-tab-bar-interaction";
 ...
   render() {
       return (
-          <TabBar bgNavBar="white" bgNavBarSelector="white" stroke="skyblue>
+          <TabBar bgNavBar="white" bgNavBarSelector="white" stroke="skyblue">
             <TabBar.Item
                 icon={require('./tab1.png')}
                 selectedIcon={require('./tab1.png')}


### PR DESCRIPTION
after about 1h searching the problem of usage i found that the line 32           <TabBar bgNavBar="white" bgNavBarSelector="white" stroke="skyblue>
MISSING a close double quote to the stroke="skyblue">